### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,27 +1,18 @@
+---
 schema: '2.0'
 stages:
-  1-stage:
-    cmd: Rscript stages/01-stage.R
-    deps:
-    - path: stages/01-stage.R
-      md5: c468dc14527e00c339f146e1dba2bd3b
-      size: 118
-    outs:
-    - path: data/mtcars.parquet
-      md5: 77cf29accf9535522fad7db1486eff9a
-      size: 6243
   download:
     cmd: bash stages/1_download.sh
     deps:
-    - path: stages/1_download.sh
-      md5: 03edb6b876f389104ff8704b739b0727
+    - md5: 03edb6b876f389104ff8704b739b0727
+      path: stages/1_download.sh
       size: 705
     outs:
-    - path: download
-      md5: 6445b53f45be37877c8c84866beaeb1a.dir
-      size: 41175180323
+    - md5: 6445b53f45be37877c8c84866beaeb1a.dir
       nfiles: 192329
-    - path: temp
-      md5: e4dcf74b1265e0ac85d9de69c509b23d.dir
-      size: 3180
+      path: download
+      size: 41175180323
+    - md5: e4dcf74b1265e0ac85d9de69c509b23d.dir
       nfiles: 1
+      path: temp
+      size: 3180


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
